### PR TITLE
Build both 2.2.x and ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,15 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+  - 2.2
+  - ruby-head
 gemfile:
   - gemfiles/rails4_0.gemfile
   - gemfiles/rails4_1.gemfile
 before_script:
   - bundle exec rake turntable:db:reset
 script: bundle exec rake spec
+matrix:
+  allow_failures:
+    - rvm: 2.2
+    - rvm: ruby-head


### PR DESCRIPTION
`2.2` points to 2.2.0-preview. When 2.2.0 is released, `2.2` points to 2.2.0

cf) https://twitter.com/travisci/statuses/513233940442644480

add `allow_failures` option because 2.2 and ruby-head is unstable yet 
