### PR TITLE
Handle string shard key

### DIFF
--- a/lib/active_record/turntable/cluster.rb
+++ b/lib/active_record/turntable/cluster.rb
@@ -37,10 +37,29 @@ module ActiveRecord::Turntable
     end
 
     def shard_for(key)
-      @shards[@algorithm.calculate(key)]
-    rescue
-      raise ActiveRecord::Turntable::CannotSpecifyShardError,
-        "cannot select_shard for key:#{key}"
+      # key is integer or string
+      # but @algorithm.calculate can handle only one type
+      is_numberic = true if Float(key) rescue false
+      if is_numberic
+        # key = numberic(ex : "123", 123)
+        [key.to_i, key.to_s].each do |k|
+          begin
+            return @shards[@algorithm.calculate(k)]
+          rescue
+          end
+        end
+        # not find...
+        raise ActiveRecord::Turntable::CannotSpecifyShardError,
+        "cannot select_shard for key:#{key}, type=#{key.class}"
+      else
+        # key = not number string(ex : "abc")
+        begin
+          @shards[@algorithm.calculate(key)]
+        rescue
+          raise ActiveRecord::Turntable::CannotSpecifyShardError,
+          "cannot select_shard for key:#{key}, type=#{key.class}"
+        end
+      end
     end
 
     def select_shard(key)


### PR DESCRIPTION
Usually, shard key is integer. but sometimes, shard key can be string.
I can't understand what happen inside library, but it happen. (shard_key=1234 is changed to shard_key="1234")
Maybe this code is cause. https://github.com/drecom/activerecord-turntable/blob/v2.1.1/lib/active_record/turntable/mixer.rb#L189
I modify code to handle shard_key="1234".
