### PR TITLE
Add error detail to Building Fader exception log

### DIFF
--- a/lib/active_record/turntable/mixer.rb
+++ b/lib/active_record/turntable/mixer.rb
@@ -48,7 +48,7 @@ module ActiveRecord::Turntable
                            method, query, *args, &block)
       end
     rescue Exception => err
-      logger.warn { "[ActiveRecord::Turntable] Error on Building Fader: #{binded_query}, on_method: #{method_name}" }
+      logger.warn { "[ActiveRecord::Turntable] Error on Building Fader: #{binded_query}, on_method: #{method_name}, err: #{err}" }
       raise err
     end
 


### PR DESCRIPTION
It is difficult to check a bug in exception log because actual query is not in there.
I added a Exception error to log. Please check this patch. 

````
[ActiveRecord::Turntable] Error on Building Fader: SELECT  `users`.* FROM `users`  WHERE `users`.`id` = '---\n- 1\n' LIMIT 1, on_method: select_all, err: [User] cannot select_shard for key:---
````
for example.
