### PR TITLE
Fix building cluster with mysql sequencer

### DIFF
--- a/lib/active_record/turntable/cluster.rb
+++ b/lib/active_record/turntable/cluster.rb
@@ -14,8 +14,11 @@ module ActiveRecord::Turntable
       @shards = {}.with_indifferent_access
 
       # setup sequencer
-      if (seq = (@options[:seq] || @config[:seq])) && seq[:type] == :mysql
-        @seq_shard = SeqShard.new(seq)
+      seq = (@options[:seq] || @config[:seq])
+      if seq 
+        if seq.values.size > 0 && seq.values.first["seq_type"] == "mysql"
+          @seq_shard = SeqShard.new(seq.values.first)
+        end
       end
 
       # setup shards

--- a/lib/active_record/turntable/seq_shard.rb
+++ b/lib/active_record/turntable/seq_shard.rb
@@ -2,6 +2,13 @@ module ActiveRecord::Turntable
   class SeqShard < Shard
     private
 
+    def create_connection_class
+      klass = get_or_set_connection_class
+      klass.remove_connection
+      klass.establish_connection ActiveRecord::Base.connection_pool.spec.config[:seq][name].with_indifferent_access
+      klass
+    end
+ 
     def retrieve_connection_pool
       ActiveRecord::Base.turntable_connections[name] ||=
         begin

--- a/lib/active_record/turntable/shard.rb
+++ b/lib/active_record/turntable/shard.rb
@@ -30,7 +30,7 @@ module ActiveRecord::Turntable
       @connection_klass ||= create_connection_class
     end
 
-    def create_connection_class
+    def get_or_set_connection_class
       if Connections.const_defined?(name.classify)
         klass = Connections.const_get(name.classify)
       else
@@ -38,6 +38,11 @@ module ActiveRecord::Turntable
         Connections.const_set(name.classify, klass)
         klass.abstract_class = true
       end
+      klass
+    end
+
+    def create_connection_class
+      klass = get_or_set_connection_class
       klass.remove_connection
       klass.establish_connection ActiveRecord::Base.connection_pool.spec.config[:shards][name].with_indifferent_access
       klass

--- a/spec/active_record/turntable/cluster_spec.rb
+++ b/spec/active_record/turntable/cluster_spec.rb
@@ -11,6 +11,8 @@ describe ActiveRecord::Turntable::Cluster do
   end
   let(:cluster_config) { ActiveRecord::Base.turntable_config[:clusters][:user_cluster] }
   let(:cluster) { ActiveRecord::Turntable::Cluster.new(cluster_config) }
+  let(:mysql_mod_cluster_config) { ActiveRecord::Base.turntable_config[:clusters][:mysql_mod_cluster] }
+  let(:mysql_mod_cluster) { ActiveRecord::Turntable::Cluster.new(mysql_mod_cluster_config) }
   let(:in_range_shard_key_value) { cluster_config[:shards].last[:less_than] - 1 }
   let(:out_of_range_shard_key_value) { cluster_config[:shards].last[:less_than] }
 
@@ -18,6 +20,13 @@ describe ActiveRecord::Turntable::Cluster do
     subject { cluster }
 
     its(:shards) { should have(3).items }
+  end
+
+  context "When initialized mysql sequencer type cluster" do
+    subject { mysql_mod_cluster }
+
+    its(:shards) { should have(2).items }
+    its(:seq)    { is_expected.not_to be nil }
   end
 
   describe "#shard_for" do

--- a/spec/config/turntable.yml
+++ b/spec/config/turntable.yml
@@ -43,4 +43,14 @@ test:
         - connection: user_shard_1
         - connection: user_shard_2
         - connection: user_shard_3
+    mysql_mod_cluster:
+      algorithm: modulo
+      seq:
+        user_seq:
+          seq_type: mysql
+          connection: user_seq
+      shards:
+        - connection: user_shard_1
+        - connection: user_shard_2
+        - connection: user_shard_2
  


### PR DESCRIPTION
Cluster の初期化構築の際にMySQL のSequencer を利用していた場合に問題がでていて
・seq_type を参照していなかった
・Sequencerに名前付けをするようになったので、階層が1つ深くなった
・Shard クラスが :shards のみを参照するようになった (昔は共有してました) 
の３点の問題があり、cluster.seq が構築されず nil になって、
デフォルトの master を参照するようになってしまっていた問題を解消してみました。