### PR TITLE
Add sequencer name to user model example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ Add turntable [shard_key_name] to the model class:
 ```ruby
 class User < ActiveRecord::Base
   turntable :user_cluster, :id
-  sequencer
+  sequencer :user_seq
   has_one :status
 end
 
 class Status < ActiveRecord::Base
   turntable :user_cluster, :user_id
-  sequencer
+  sequencer :user_seq
   belongs_to :user
 end
 ```


### PR DESCRIPTION
現状Sequencer の名前はMySQLでも必須なのでREADME修正します.