### PR TITLE
[Travis] Migrating from legacy to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script: bundle exec rake spec
 matrix:
   allow_failures:
     - rvm: ruby-head
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 sudo: false
+cache: bundler


### PR DESCRIPTION
Resolved this warning 

![2015-07-13 2 07 33](https://cloud.githubusercontent.com/assets/608755/8638928/8c514762-2904-11e5-9f33-5f2a2f0e6be4.png)

and enable bundler caching

# details
* [Migrating from legacy to container-based infrastructure - Travis CI](http://docs.travis-ci.com/user/migrating-from-legacy/)
* [Caching Dependencies and Directories - Travis CI](http://docs.travis-ci.com/user/caching/)