### PR TITLE
Avoid constant double initialize warning

### DIFF
--- a/lib/active_record/turntable/sql_tree_patch.rb
+++ b/lib/active_record/turntable/sql_tree_patch.rb
@@ -10,7 +10,7 @@ end
 
 class SQLTree::Token
   extended_keywords = ['BINARY', 'LIMIT', 'OFFSET', 'INDEX', 'KEY', 'USE', 'FORCE', 'IGNORE']
-  KEYWORDS += extended_keywords
+  KEYWORDS.concat(extended_keywords)
 
   extended_keywords.each do |kwd|
     const_set(kwd, Class.new(SQLTree::Token::Keyword))


### PR DESCRIPTION
**NOTE This PR is to the index hint branch**

Suppresses the warning below:

```
/path/to/activerecord-turntable/lib/active_record/turntable/sql_tree_patch.rb:13: warning: already initialized constant SQLTree::Token::KEYWORDS
/path/to/sql_tree-0.2.0/lib/sql_tree/token.rb:146: warning: previous definition of KEYWORDS was here
```
