### PR TITLE
ConnectionProxy uses a `method_missing`, so it should adapt a `respond_to?`

### DIFF
--- a/lib/active_record/turntable/connection_proxy.rb
+++ b/lib/active_record/turntable/connection_proxy.rb
@@ -68,6 +68,10 @@ module ActiveRecord::Turntable
       end
     end
 
+    def respond_to_missing?(method, include_private = false)
+      connection.send(:respond_to?, method, include_private)
+    end
+
     def to_sql(arel, binds = [])
       master.connection.to_sql(arel, binds)
     end


### PR DESCRIPTION
I added a `ActiveRecord::Turntable::ConnectionProxy#respond_to_missing?`.
Models that enable the turntable connect a `connection` through a `ActiveRecord::Turntable::ConnectionProxy#method_missing`, so if you use a `respond_to?` for the connection, it returns almost `false`.

For example, when I use the activerecord-import too with fixing shard, it’s disabled for that reason.
https://github.com/zdennis/activerecord-import/blob/c0a4393a62fccd0c572266795f0c787ddf3a1775/lib/activerecord-import/import.rb#L112

This PR solves the problem.