### PR TITLE
ActiveRecord::Import follow ActiveRecord 5

### DIFF
--- a/lib/active_record/turntable/active_record_ext/activerecord_import_ext.rb
+++ b/lib/active_record/turntable/active_record_ext/activerecord_import_ext.rb
@@ -11,6 +11,7 @@ module ActiveRecord::Turntable
       private
 
       # @note override for sequencer injection
+      # @see https://github.com/zdennis/activerecord-import/blob/ba909fed5a4785fe9c7cce89e48e1242bb6804ea/lib/activerecord-import/import.rb#L558-L581
       def values_sql_for_columns_and_attributes_with_turntable(columns, array_of_attributes)
         connection_memo = connection
         array_of_attributes.map do |arr|
@@ -24,11 +25,13 @@ module ActiveRecord::Turntable
               else
                 connection_memo.next_value_for_sequence(sequence_name)
               end
-            else
-              if serialized_attributes.include?(column.name)
-                connection_memo.quote(serialized_attributes[column.name].dump(val), column)
-              else
-                connection_memo.quote(val, column)
+            elsif column
+              if respond_to?(:type_caster) && type_caster.respond_to?(:type_cast_for_database) # Rails 5.0 and higher
+                connection_memo.quote(type_caster.type_cast_for_database(column.name, val))
+              elsif column.respond_to?(:type_cast_from_user)                      # Rails 4.2 and higher
+                connection_memo.quote(column.type_cast_from_user(val), column)
+              else                                                                # Rails 3.1, 3.2, and 4.1
+                connection_memo.quote(column.type_cast(val), column)
               end
             end
           end


### PR DESCRIPTION
DEPRECATION WARNING:
 * `serialized_attributes` is deprecated without replacement, and will be removed in Rails 5.0.

https://github.com/rails/rails/commit/2df1540143f1a57ab7aae8ff926266cc233292c5