### PR TITLE
Re-enable the `AR::LogSubscriber::IGNORE_PAYLOAD_NAMES`

### DIFF
--- a/lib/active_record/turntable/active_record_ext/log_subscriber.rb
+++ b/lib/active_record/turntable/active_record_ext/log_subscriber.rb
@@ -6,6 +6,12 @@ module ActiveRecord::Turntable
       # @note prepend to add shard name logging
       def sql(event)
         payload = event.payload
+
+        if self.class::IGNORE_PAYLOAD_NAMES.include?(payload[:name])
+          self.class.runtime += event.duration
+          return
+        end
+
         if payload[:turntable_shard_name]
           payload[:name] = "#{payload[:name]} [Shard: #{payload[:turntable_shard_name]}]"
         end

--- a/spec/active_record/turntable/active_record_ext/log_subscriber_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/log_subscriber_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe ActiveRecord::Turntable::ActiveRecordExt::LogSubscriber do
+  before(:all) do
+    reload_turntable!(File.join(File.dirname(__FILE__), "../../../config/turntable.yml"))
+  end
+
+  before(:each) do
+    establish_connection_to
+  end
+
+  class TestLogSubscriber < ActiveRecord::LogSubscriber
+    attr_reader :debugs
+
+    def initialize
+      @debugs = []
+      super
+    end
+
+    def debug(message)
+      @debugs << message
+    end
+  end
+
+  TestEvent = Struct.new(:payload) do
+    def sql
+      "foo"
+    end
+
+    def duration
+      0
+    end
+  end
+
+  describe "#sql" do
+    it "ignore SCHEMA log" do
+      subscriber = TestLogSubscriber.new
+      expect(subscriber.debugs.length).to eq 0
+
+      subscriber.sql(TestEvent.new(name: "bar", turntable_shard_name: "shard_1"))
+      expect(subscriber.debugs.length).to eq 1
+
+      subscriber.sql(TestEvent.new(name: "SCHEMA", turntable_shard_name: "shard_1"))
+      expect(subscriber.debugs.length).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
The definition was used until version 2.x, but the commit below made that unused.
https://github.com/drecom/activerecord-turntable/commit/2ad357dab40aedde25d12838e208f56442f9f555

---

Before:
```
irb(main):001:0> User.create
  SCHEMA [Shard: master] (0.5ms)  SELECT table_name FROM information_schema.tables WHERE table_schema = 'sample_app_development'
  SCHEMA [Shard: master] (4.9ms)  SELECT column_name
FROM information_schema.key_column_usage
WHERE constraint_name = 'PRIMARY'
  AND table_schema = 'sample_app_development'
  AND table_name = 'users'
ORDER BY ordinal_position

  SCHEMA [Shard: master] (0.4ms)  SHOW FULL FIELDS FROM `users`
   [Shard: user_seq] (2.1ms)  UPDATE `users_id_seq` SET id=LAST_INSERT_ID(id+1)
   [Shard: user_seq] (0.2ms)  SELECT LAST_INSERT_ID()
   [Shard: user_shard_1] (0.1ms)  BEGIN
[ActiveRecord::Turntable] Sending method: insert, sql: #<Arel::InsertManager:0x007f97d9f4ebb0>, shards: ["user_shard_1"]
  SQL [Shard: user_shard_1] (1.4ms)  INSERT INTO `users` (`id`, `created_at`, `updated_at`) VALUES (3, '2017-01-21 17:18:18', '2017-01-21 17:18:18')
   [Shard: user_shard_1] (5.8ms)  COMMIT
=> #<User id: 3, name: nil, created_at: "2017-01-21 17:18:18", updated_at: "2017-01-21 17:18:18">
```

After:
```
irb(main):001:0> User.create
   [Shard: user_seq] (2.6ms)  UPDATE `users_id_seq` SET id=LAST_INSERT_ID(id+1)
   [Shard: user_seq] (0.2ms)  SELECT LAST_INSERT_ID()
   [Shard: user_shard_1] (0.2ms)  BEGIN
[ActiveRecord::Turntable] Sending method: insert, sql: #<Arel::InsertManager:0x007fe8aa333520>, shards: ["user_shard_1"]
  SQL [Shard: user_shard_1] (15.5ms)  INSERT INTO `users` (`id`, `created_at`, `updated_at`) VALUES (4, '2017-01-21 17:28:57', '2017-01-21 17:28:57')
   [Shard: user_shard_1] (6.1ms)  COMMIT
=> #<User id: 4, name: nil, created_at: "2017-01-21 17:28:57", updated_at: "2017-01-21 17:28:57">
```