### PR TITLE
Fix to pass transaction options to original transaction method

### DIFF
--- a/lib/active_record/turntable/cluster_helper_methods.rb
+++ b/lib/active_record/turntable/cluster_helper_methods.rb
@@ -54,12 +54,12 @@ module ActiveRecord::Turntable
 
       def all_cluster_transaction(options = {})
         clusters = turntable_clusters.values
-        recursive_cluster_transaction(clusters) { yield }
+        recursive_cluster_transaction(clusters, options) { yield }
       end
 
       def recursive_cluster_transaction(clusters, options = {}, &block)
         current_cluster = clusters.shift
-        current_cluster.shards_transaction do
+        current_cluster.shards_transaction([], options) do
           if clusters.present?
             recursive_cluster_transaction(clusters, options, &block)
           else

--- a/spec/active_record/turntable/cluster_helper_methods_spec.rb
+++ b/spec/active_record/turntable/cluster_helper_methods_spec.rb
@@ -20,6 +20,14 @@ describe ActiveRecord::Turntable::ClusterHelperMethods do
         expect(shards.map(&:connection).map(&:open_transactions)).to all(be == 1)
       }
     end
+
+    it "`requires_new` option should be passed to original transaction method" do
+      User.all_cluster_transaction {
+        User.all_cluster_transaction(requires_new: true) {
+          expect(shards.map(&:connection).map(&:open_transactions)).to all(be > 1)
+        }
+      }
+    end
   end
 
   describe ".cluster_transaction" do


### PR DESCRIPTION
`:requires_new` option was not passed correctly