### PR TITLE
Fixed set of `@turntable_shard_name`

### DIFF
--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -36,7 +36,7 @@ module ActiveRecord::Turntable
       end
 
       def turntable_shard_name
-        @turntable_shard_name ||= ""
+        instance_variable_defined?(:@turntable_shard_name) ? @turntable_shard_name : nil
       end
     end
   end


### PR DESCRIPTION
Returning empty string will not assign a name.

https://github.com/drecom/activerecord-turntable/blob/58ffda1d447d51012741e5d74c94d37ca9cfd0b4/lib/active_record/turntable/shard.rb#L26