### PR TITLE
get table_options as string

### DIFF
--- a/lib/active_record/turntable/active_record_ext/schema_dumper.rb
+++ b/lib/active_record/turntable/active_record_ext/schema_dumper.rb
@@ -42,7 +42,12 @@ module ActiveRecord::Turntable
             end
             tbl.print ", force: :cascade"
 
-            table_options = @connection.table_options(table)
+            table_options = case @connection.table_options(table)
+                            when Hash
+                              @connection.table_options(table)[:options]
+                            else
+                              @connection.table_options(table)
+                            end
             tbl.print ", options: #{table_options.inspect}" unless table_options.blank?
 
             if comment = @connection.table_comment(table).presence


### PR DESCRIPTION
The data type of the return value is Hash.
detail is here.
https://github.com/rails/rails/blob/8b69e32412cc2867b5fdd9a33cf4e4e759057e95/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L442

I fix to if the data value is hash, 
I modified to get a value of table_options[:options] if the return value of table_options is hash.