### PR TITLE
Fix LogSubscriber log format

### DIFF
--- a/lib/active_record/turntable/active_record_ext/log_subscriber.rb
+++ b/lib/active_record/turntable/active_record_ext/log_subscriber.rb
@@ -5,17 +5,30 @@ module ActiveRecord::Turntable
     module LogSubscriber
       # @note prepend to add shard name logging
       def sql(event)
+        self.class.runtime += event.duration
+        return unless logger.debug?
+
         payload = event.payload
 
-        if self.class::IGNORE_PAYLOAD_NAMES.include?(payload[:name])
-          self.class.runtime += event.duration
-          return
+        return if ActiveRecord::LogSubscriber::IGNORE_PAYLOAD_NAMES.include?(payload[:name])
+
+        name  = "#{payload[:name]} (#{event.duration.round(1)}ms)"
+        name  = "#{name} [Shard: #{payload[:turntable_shard_name]}]" if payload[:turntable_shard_name]
+        name  = "CACHE #{name}" if payload[:cached]
+        sql   = payload[:sql]
+        binds = nil
+
+        unless (payload[:binds] || []).empty?
+          casted_params = type_casted_binds(payload[:binds], payload[:type_casted_binds])
+          binds = "  " + payload[:binds].zip(casted_params).map { |attr, value|
+            render_bind(attr, value)
+          }.inspect
         end
 
-        if payload[:turntable_shard_name]
-          payload[:name] = "#{payload[:name]} [Shard: #{payload[:turntable_shard_name]}]"
-        end
-        super
+        name = colorize_payload_name(name, payload[:name])
+        sql  = color(sql, sql_color(sql), true)
+
+        debug "  #{name}  #{sql}#{binds}"
       end
     end
   end

--- a/spec/active_record/turntable/active_record_ext/log_subscriber_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/log_subscriber_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe ActiveRecord::Turntable::ActiveRecordExt::LogSubscriber do
+  REGEXP_MAGENTA = Regexp.escape(ActiveRecord::LogSubscriber::MAGENTA)
+  REGEXP_CYAN = Regexp.escape(ActiveRecord::LogSubscriber::CYAN)
+  REGEXP_CLEAR = Regexp.escape(ActiveRecord::LogSubscriber::CLEAR)
+
   class TestLogSubscriber < ActiveRecord::LogSubscriber
     attr_reader :debugs
 
@@ -25,8 +29,9 @@ describe ActiveRecord::Turntable::ActiveRecordExt::LogSubscriber do
   end
 
   describe "#sql" do
+    let(:subscriber) { TestLogSubscriber.new }
+
     it "ignore SCHEMA log" do
-      subscriber = TestLogSubscriber.new
       expect(subscriber.debugs.length).to eq 0
 
       subscriber.sql(TestEvent.new(name: "bar", turntable_shard_name: "shard_1"))
@@ -34,6 +39,20 @@ describe ActiveRecord::Turntable::ActiveRecordExt::LogSubscriber do
 
       subscriber.sql(TestEvent.new(name: "SCHEMA", turntable_shard_name: "shard_1"))
       expect(subscriber.debugs.length).to eq 1
+    end
+
+    context "When payload name is `SQL`" do
+      it "logs in MAGENTA color" do
+        subscriber.sql(TestEvent.new(name: "SQL", turntable_shard_name: "shard_1"))
+        expect(subscriber.debugs.first).to match(/#{REGEXP_MAGENTA}SQL \(0\.0ms\) \[Shard: shard_1\]#{REGEXP_CLEAR}/)
+      end
+    end
+
+    context "When payload name is `Model Load`" do
+      it "logs in CYAN color" do
+        subscriber.sql(TestEvent.new(name: "Model Load", turntable_shard_name: "shard_1"))
+        expect(subscriber.debugs.first).to match(/#{REGEXP_CYAN}Model Load \(0\.0ms\) \[Shard: shard_1\]#{REGEXP_CLEAR}/)
+      end
     end
   end
 end


### PR DESCRIPTION
This commit revert log format to be the same as activerecord-turntable 2.x and
fix colorizing as original AR::LogSubscriber.

before:

  SQL [Shard: shard_1] (0.0ms) XXXX

after:

  SQL (0.0ms) [Shard: shard_1] XXXX