### PR TITLE
Fix migrator extension to return original value of super

### DIFF
--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -104,30 +104,33 @@ module ActiveRecord::Turntable::Migration
 
     module ClassMethods
       def up(migrations_paths, target_version = nil)
-        super
+        result = super
 
         ActiveRecord::Tasks::DatabaseTasks.each_current_turntable_cluster_connected(current_environment) do |name, configuration|
           puts "[turntable] *** Migrating database: #{configuration['database']}(Shard: #{name})"
           super(migrations_paths, target_version)
         end
+        result
       end
 
       def down(migrations_paths, target_version = nil, &block)
-        super
+        result = super
 
         ActiveRecord::Tasks::DatabaseTasks.each_current_turntable_cluster_connected(current_environment) do |name, configuration|
           puts "[turntable] *** Migrating database: #{configuration['database']}(Shard: #{name})"
           super(migrations_paths, target_version, &block)
         end
+        result
       end
 
       def run(*args)
-        super
+        result = super
 
         ActiveRecord::Tasks::DatabaseTasks.each_current_turntable_cluster_connected(current_environment) do |name, configuration|
           puts "[turntable] *** Migrating database: #{configuration['database']}(Shard: #{name})"
           super(*args)
         end
+        result
       end
     end
   end


### PR DESCRIPTION
Because activerecord tests check it.