### PR TITLE
Fix schema dumper to dump sequence table options correctly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,7 @@ namespace :turntable do
       configurations.each do |configuration|
         ActiveRecord::Base.establish_connection configuration
 
-        ActiveRecord::Base.connection.create_table :users do |t|
+        ActiveRecord::Base.connection.create_table :users, comment: "comment" do |t|
           t.string :nickname
           t.string :thumbnail_url
           t.binary :blob
@@ -56,7 +56,7 @@ namespace :turntable do
           t.datetime :deleted_at
           t.timestamps
         end
-        ActiveRecord::Base.connection.create_sequence_for :users
+        ActiveRecord::Base.connection.create_sequence_for :users, comment: "comment"
 
         ActiveRecord::Base.connection.create_table :user_statuses do |t|
           t.belongs_to :user, :null => false

--- a/lib/active_record/turntable/active_record_ext/schema_dumper.rb
+++ b/lib/active_record/turntable/active_record_ext/schema_dumper.rb
@@ -20,11 +20,14 @@ module ActiveRecord::Turntable
 
             table_options = @connection.table_options(table)
             if table_options.present?
-              options = respond_to?(:format_options) ? format_options(table_options) : table_options.inspect
-              tbl.print ", options: #{options}"
+              if respond_to?(:format_options, true)
+                tbl.print ", #{format_options(table_options)}"
+              else
+                tbl.print ", options: #{table_options.inspect}"
+              end
             end
 
-            if comment = @connection.table_comment(table).presence
+            if Util.ar_version_earlier_than?("5.0.1") && comment = @connection.table_comment(table).presence
               tbl.print ", comment: #{comment.inspect}"
             end
             tbl.puts

--- a/spec/active_record/turntable/active_record_ext/schema_dumper_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/schema_dumper_spec.rb
@@ -9,7 +9,12 @@ describe ActiveRecord::Turntable::ActiveRecordExt::SchemaDumper do
 
   context "#dump" do
     subject { dump_schema }
-    it { is_expected.to match(/create_sequence_for "users", force: :cascade, options: /) }
+
+    if ActiveRecord::Turntable::Util.ar_version_equals_or_later?("5.0.1")
+      it { is_expected.to match(/create_sequence_for "users", force: :cascade, options: "[^"]+", comment: "[^"]+"$/) }
+    else
+      it { is_expected.to match(/create_sequence_for "users", force: :cascade, options: "[^"]+"/) }
+    end
     it { is_expected.not_to match(/create_table "users_id_seq"/) }
     it { is_expected.not_to match(/create_sequence_for "users_id_seq".*?do/) }
   end


### PR DESCRIPTION
before:

  create_sequence_for "users", force: :cascade, options: {:options =>
  xxxx, :comment => xxxx}, comment: xxxx

after

  create_sequence_for "users", force: :cascade, options: "xxxx", comment: xxxx