### PR TITLE
Inspect shard key on CannotSpecifyShardError messages

### DIFF
--- a/lib/active_record/turntable/algorithm/modulo_algorithm.rb
+++ b/lib/active_record/turntable/algorithm/modulo_algorithm.rb
@@ -8,7 +8,7 @@ module ActiveRecord::Turntable::Algorithm
     def calculate(key)
       @config[:shards][key % @config[:shards].size][:connection]
     rescue
-      raise ActiveRecord::Turntable::CannotSpecifyShardError, "cannot specify shard for key:#{key}"
+      raise ActiveRecord::Turntable::CannotSpecifyShardError, "cannot specify shard for key:#{key.inspect}"
     end
   end
 end

--- a/lib/active_record/turntable/algorithm/range_algorithm.rb
+++ b/lib/active_record/turntable/algorithm/range_algorithm.rb
@@ -9,7 +9,7 @@ module ActiveRecord::Turntable::Algorithm
       idx = calculate_idx(key)
       @config[:shards][idx][:connection]
     rescue
-      raise ActiveRecord::Turntable::CannotSpecifyShardError, "cannot specify shard for key:#{key}"
+      raise ActiveRecord::Turntable::CannotSpecifyShardError, "cannot specify shard for key:#{key.inspect}"
     end
 
     def calculate_idx(key)

--- a/lib/active_record/turntable/algorithm/range_bsearch_algorithm.rb
+++ b/lib/active_record/turntable/algorithm/range_bsearch_algorithm.rb
@@ -11,7 +11,7 @@ module ActiveRecord::Turntable::Algorithm
       idx = calculate_idx(key)
       @config[:shards][idx][:connection]
     rescue
-      raise ActiveRecord::Turntable::CannotSpecifyShardError, "cannot specify shard for key:#{key}"
+      raise ActiveRecord::Turntable::CannotSpecifyShardError, "cannot specify shard for key:#{key.inspect}"
     end
 
     def calculate_idx(key)

--- a/lib/active_record/turntable/cluster.rb
+++ b/lib/active_record/turntable/cluster.rb
@@ -40,7 +40,7 @@ module ActiveRecord::Turntable
       @shards[@algorithm.calculate(key)]
     rescue
       raise ActiveRecord::Turntable::CannotSpecifyShardError,
-            "cannot select_shard for key:#{key}"
+            "cannot select shard for key:#{key.inspect}"
     end
 
     def select_shard(key)


### PR DESCRIPTION
Make it easier to understand when key is nil

before:

  cannot specify shard for key:

after:

  cannot specify shard for key:nil