### PR TITLE
factory_girl to factory_bot

### DIFF
--- a/activerecord-turntable.gemspec
+++ b/activerecord-turntable.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activerecord-import"
   spec.add_development_dependency "barrage"
   spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "factory_girl"
+  spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "faker"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency "guard-rubocop"

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :item do
     name { Faker::Food.name }
   end

--- a/spec/factories/user_event_histories.rb
+++ b/spec/factories/user_event_histories.rb
@@ -1,3 +1,3 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user_event_history
 end

--- a/spec/factories/user_item_histories.rb
+++ b/spec/factories/user_item_histories.rb
@@ -1,3 +1,3 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user_item_history
 end

--- a/spec/factories/user_items.rb
+++ b/spec/factories/user_items.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user_item do
     item
 

--- a/spec/factories/user_profiles.rb
+++ b/spec/factories/user_profiles.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user_profile do
     birthday { Faker::Date.birthday }
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     sequence(:id, 1)
     nickname { Faker::Name.name }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,9 +44,9 @@ RSpec.configure do |config|
     reload_turntable!(File.join(File.dirname(__FILE__), "config/turntable.rb"), :test)
   end
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.before(:suite) do
-    FactoryGirl.find_definitions
+    FactoryBot.find_definitions
   end
 
   config.before(:each) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ require "rspec/rails"
 require "webmock/rspec"
 require "timecop"
 require "pry-byebug"
-require "factory_girl"
+require "factory_bot"
 require "faker"
 
 require "coveralls"


### PR DESCRIPTION
I resolved the following deprecation warning

```
DEPRECATION WARNING: The factory_girl gem is deprecated. Please upgrade to factory_bot. See https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md for further instructions. (called from <top (required)> at /home/travis/build/drecom/activerecord-turntable/spec/spec_helper.rb:21)
```

https://travis-ci.org/drecom/activerecord-turntable/jobs/323558521