### PR TITLE
Fixes sql parser errors when inserting values with boolean columns

### DIFF
--- a/spec/active_record/turntable/mixer_spec.rb
+++ b/spec/active_record/turntable/mixer_spec.rb
@@ -27,6 +27,18 @@ describe ActiveRecord::Turntable::Mixer do
     end
   end
 
+  context "#build_insert_fader" do
+    context "with boolean `TRUE` column value" do
+      subject { UserProfile.create(user: user, published: true) }
+
+      let(:user) { create(:user) }
+
+      it { expect { subject }.not_to raise_error }
+      its(:errors) { is_expected.to be_empty }
+      its(:published) { is_expected.to eq(true) }
+    end
+  end
+
   context "#find_shard_keys" do
     subject { @mixer.find_shard_keys(sql_tree.where, "users", "id") }
 

--- a/spec/factories/user_profiles.rb
+++ b/spec/factories/user_profiles.rb
@@ -1,10 +1,16 @@
 FactoryBot.define do
   factory :user_profile do
     birthday { Faker::Date.birthday }
+    published { false }
+    user
 
     trait :created_yesterday do
-      created_at 1.day.ago
-      updated_at 1.day.ago
+      created_at { 1.day.ago }
+      updated_at { 1.day.ago }
+    end
+
+    trait :published do
+      published { true }
     end
   end
 end

--- a/spec/migrations/schema.rb
+++ b/spec/migrations/schema.rb
@@ -13,6 +13,7 @@ ActiveRecord::Schema.define do
     t.belongs_to :user, null: false
     t.date       :birthday
     t.text       :data
+    t.boolean    :published, null: false, default: false
     t.integer    :lock_version, null: false, default: 0
     t.datetime   :deleted_at, default: nil
     t.timestamps


### PR DESCRIPTION
On rails v5.2.0 or later, activerecord uses `TRUE` and `FALSE` literals for MySQL

ref rails/rails@c1972c2640