### PR TITLE
Separate PoolProxy from `owner_to_pool`

### DIFF
--- a/lib/active_record/turntable/active_record_ext/connection_handler_extension.rb
+++ b/lib/active_record/turntable/active_record_ext/connection_handler_extension.rb
@@ -1,28 +1,14 @@
 module ActiveRecord::Turntable
   module ActiveRecordExt
     module ConnectionHandlerExtension
+      def owner_to_turntable_pool
+        @owner_to_turntable_pool ||= Concurrent::Map.new(initial_capacity: 2)
+      end
+
       # @note Override not to establish_connection destroy existing connection pool proxy object
       def retrieve_connection_pool(spec_name)
-        owner_to_pool.fetch(spec_name) do
-          # Check if a connection was previously established in an ancestor process,
-          # which may have been forked.
-          if ancestor_pool = pool_from_any_process_for(spec_name)
-            if ancestor_pool.is_a?(ActiveRecord::ConnectionAdapters::ConnectionPool)
-              # A connection was established in an ancestor process that must have
-              # subsequently forked. We can't reuse the connection, but we can copy
-              # the specification and establish a new connection with it.
-              spec = ancestor_pool.spec
-              spec = spec.to_hash if spec.respond_to?(:to_hash)
-              establish_connection(spec).tap do |pool|
-                pool.schema_cache = ancestor_pool.schema_cache if ancestor_pool.schema_cache
-              end
-            else
-              # Use same PoolProxy object
-              owner_to_pool[spec_name] = ancestor_pool
-            end
-          else
-            owner_to_pool[spec_name] = nil
-          end
+        owner_to_turntable_pool.fetch(spec_name) do
+          super
         end
       end
     end

--- a/lib/active_record/turntable/base.rb
+++ b/lib/active_record/turntable/base.rb
@@ -61,7 +61,7 @@ module ActiveRecord::Turntable
         pp = PoolProxy.new(cp)
 
         self.connection_specification_name = "turntable_pool_proxy::#{name}"
-        ch.send(:owner_to_pool)[connection_specification_name] = pp
+        ch.owner_to_turntable_pool[connection_specification_name] = pp
       end
 
       def sequencer(sequencer_name, *args)

--- a/spec/active_record/turntable/active_record_ext/connection_handler_extension_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/connection_handler_extension_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper"
+require "active_record/turntable/active_record_ext/connection_handler_extension"
+
+describe ActiveRecord::Turntable::ActiveRecordExt::ConnectionHandlerExtension do
+  it "connection_pool_list should not include PoolProxy" do
+    expect(ActiveRecord::Base.connection_handler.connection_pool_list).to all(be_instance_of(ActiveRecord::ConnectionAdapters::ConnectionPool))
+  end
+end

--- a/spec/active_record/turntable/active_record_ext/query_cache_spec.rb
+++ b/spec/active_record/turntable/active_record_ext/query_cache_spec.rb
@@ -100,4 +100,15 @@ describe ActiveRecord::Turntable::ActiveRecordExt::QueryCache do
     }
     expect(mw.call({})).to eq([1, 0, 0])
   end
+
+  context "After QueryCache middleware calls" do
+    self.use_transactional_tests = false
+
+    it "releases all active connections" do
+      mw = middleware {}
+
+      ActiveRecord::Base.all_cluster_transaction {}
+      expect { mw.call({}) }.to change { ObjectSpace.each_object(ActiveRecord::ConnectionAdapters::ConnectionPool).any? { |c| c.active_connection? } }.to(false)
+    end
+  end
 end


### PR DESCRIPTION
to prevent duplicated connection handling method calls when releasing connections
that causes performance degradation.

All of ConnectionAdapter objects are included in `owner_to_pool` natively,
so it doesn't have to include PoolProxy objects.